### PR TITLE
Fixed printf without format specifiers.

### DIFF
--- a/xtor.c
+++ b/xtor.c
@@ -1570,7 +1570,7 @@ main(int argc, char *argv[])
     switch (c) {
       case 'c': controller_name = optarg; break;
       case 'u': gladename = optarg; break;
-      case 'h': printf(usage); return 0;
+      case 'h': printf("%s", usage); return 0;
       case '?': return 1;
       case 0:
       default: break;


### PR DESCRIPTION
I don't think that a format string exploit was possible here because the string usage is hardcoded but better be safe than sorry. Thanks for this tool. I feared I had to write something myself. I might contribute more patches if I have time and you would like me to.